### PR TITLE
correcting nginx deploy file

### DIFF
--- a/nginx-deployment.yaml
+++ b/nginx-deployment.yaml
@@ -1,22 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: nginx
-  name: nginx
+  name: nginx-deploy
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.service: nginx
+        app: nginx
     spec:
       containers:
-      - image: nginx:tag
-        name: nginx
+      - name: nginx
+        image: kkgujjar/nginx:v1
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         resources: {}


### PR DESCRIPTION
i can create the pod with this configuration, but pod still is in down state. reason : application error 
attaching logs : 
<img width="954" alt="image" src="https://user-images.githubusercontent.com/9307818/146665049-28ce38e8-6573-4ef1-af1d-f77a8e24c8e8.png">

❯ kubectl get pod
NAME                            READY   STATUS             RESTARTS       AGE
nginx-deploy-6df76c896b-9v228   0/1     CrashLoopBackOff   6 (5m1s ago)   13m

❯ kubectl get deploy
NAME           READY   UP-TO-DATE   AVAILABLE   AGE
nginx-deploy   0/1     1            0           13m